### PR TITLE
Allow binary download location to be specified

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -14,10 +14,14 @@ mkdir -p "$1" "$2"
 BUILD_DIR=$(cd "$1/" && pwd)
 ENV_DIR=$(cd "$1/" && pwd)
 
-echo "-----> Installing sprettur"
+DEFAULT_SPRETTUR_URL=https://sprettur.herokuapp.com/sprettur
+SPECIFIED_SPRETTUR_URL=$(cat $ENV_DIR/SPRETTUR_URL)
+SPRETTUR_URL=${SPECIFIED_SPRETTUR_URL:-$DEFAULT_SPRETTUR_URL}
+
+echo '-----> Installing sprettur from $SPRETTUR_URL'
 SPRETTUR_DIR=$BUILD_DIR/.sprettur/bin
 mkdir -p $SPRETTUR_DIR
-curl -s -o $SPRETTUR_DIR/sprettur https://sprettur.herokuapp.com/sprettur
+curl -s -o $SPRETTUR_DIR/sprettur $SPRETTUR_URL
 chmod +x $SPRETTUR_DIR/sprettur
 
 echo "-----> Removing Procfile"

--- a/bin/compile
+++ b/bin/compile
@@ -23,7 +23,6 @@ fi
 
 echo "-----> Installing sprettur"
 SPRETTUR_DIR=$BUILD_DIR/.sprettur/bin
-
 mkdir -p $SPRETTUR_DIR
 curl -s -o $SPRETTUR_DIR/sprettur $SPRETTUR_URL
 chmod +x $SPRETTUR_DIR/sprettur

--- a/bin/compile
+++ b/bin/compile
@@ -12,12 +12,16 @@ unset GIT_DIR
 # Directories
 mkdir -p "$1" "$2"
 BUILD_DIR=$(cd "$1/" && pwd)
-ENV_DIR=$(cd "$1/" && pwd)
+ENV_DIR=$(cd "$2/" && pwd)
+
+# Detect download location for sprettur binary
+if [ -f $ENV_DIR/SPRETTUR_URL ]; then
+  SPRETTUR_URL=$(cat $ENV_DIR/SPRETTUR_URL)
+else
+  SPRETTUR_URL=https://sprettur.herokuapp.com/sprettur
+fi
 
 echo "-----> Installing sprettur"
-DEFAULT_SPRETTUR_URL=https://sprettur.herokuapp.com/sprettur
-SPECIFIED_SPRETTUR_URL=$(cat $ENV_DIR/SPRETTUR_URL)
-SPRETTUR_URL=${SPECIFIED_SPRETTUR_URL:-$DEFAULT_SPRETTUR_URL}
 SPRETTUR_DIR=$BUILD_DIR/.sprettur/bin
 
 mkdir -p $SPRETTUR_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -15,8 +15,8 @@ BUILD_DIR=$(cd "$1/" && pwd)
 ENV_DIR=$(cd "$2/" && pwd)
 
 # Detect download location for sprettur binary
-if [ -f $ENV_DIR/SPRETTUR_URL ]; then
-  SPRETTUR_URL=$(cat $ENV_DIR/SPRETTUR_URL)
+if [ -f $ENV_DIR/HEROKU_SPRETTUR_URL ]; then
+  SPRETTUR_URL=$(cat $ENV_DIR/HEROKU_SPRETTUR_URL)
 else
   SPRETTUR_URL=https://sprettur.herokuapp.com/sprettur
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -14,12 +14,12 @@ mkdir -p "$1" "$2"
 BUILD_DIR=$(cd "$1/" && pwd)
 ENV_DIR=$(cd "$1/" && pwd)
 
+echo "-----> Installing sprettur"
 DEFAULT_SPRETTUR_URL=https://sprettur.herokuapp.com/sprettur
 SPECIFIED_SPRETTUR_URL=$(cat $ENV_DIR/SPRETTUR_URL)
 SPRETTUR_URL=${SPECIFIED_SPRETTUR_URL:-$DEFAULT_SPRETTUR_URL}
-
-echo '-----> Installing sprettur from $SPRETTUR_URL'
 SPRETTUR_DIR=$BUILD_DIR/.sprettur/bin
+
 mkdir -p $SPRETTUR_DIR
 curl -s -o $SPRETTUR_DIR/sprettur $SPRETTUR_URL
 chmod +x $SPRETTUR_DIR/sprettur


### PR DESCRIPTION
This allows a test run, or an entire pipeline to specify which sprettur it wants to use, with a default fallback to production. This is useful for integration tests on new sprettur features/changes.