### PR TITLE
Better logging; fix HEROKU_SPRETTUR_URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,10 @@ BUILD_DIR=$(cd "$1/" && pwd)
 ENV_DIR=$(cd "$2/" && pwd)
 
 # Detect download location for sprettur binary
+echo $ENV_DIR
+ls $ENV_DIR
+cat "$ENV_DIR/HEROKU_SPRETTUR_URL"
+
 if [ -f $ENV_DIR/HEROKU_SPRETTUR_URL ]; then
   SPRETTUR_URL=$(cat $ENV_DIR/HEROKU_SPRETTUR_URL)
   echo "-----> Installing sprettur from $SPRETTUR_URL"

--- a/bin/compile
+++ b/bin/compile
@@ -17,11 +17,12 @@ ENV_DIR=$(cd "$2/" && pwd)
 # Detect download location for sprettur binary
 if [ -f $ENV_DIR/HEROKU_SPRETTUR_URL ]; then
   SPRETTUR_URL=$(cat $ENV_DIR/HEROKU_SPRETTUR_URL)
+  echo "-----> Installing sprettur from $SPRETTUR_URL"
 else
+  echo "-----> Installing sprettur"
   SPRETTUR_URL=https://sprettur.herokuapp.com/sprettur
 fi
 
-echo "-----> Installing sprettur"
 SPRETTUR_DIR=$BUILD_DIR/.sprettur/bin
 mkdir -p $SPRETTUR_DIR
 curl -s -o $SPRETTUR_DIR/sprettur $SPRETTUR_URL

--- a/bin/compile
+++ b/bin/compile
@@ -10,9 +10,9 @@ set -o pipefail   # do not ignore exit codes when piping output
 unset GIT_DIR
 
 # Directories
-mkdir -p "$1" "$2"
+mkdir -p "$1" "$2" "$3"
 BUILD_DIR=$(cd "$1/" && pwd)
-ENV_DIR=$(cd "$2/" && pwd)
+ENV_DIR=$(cd "$3/" && pwd)
 
 # Detect download location for sprettur binary
 echo $ENV_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -15,10 +15,6 @@ BUILD_DIR=$(cd "$1/" && pwd)
 ENV_DIR=$(cd "$3/" && pwd)
 
 # Detect download location for sprettur binary
-echo $ENV_DIR
-ls $ENV_DIR
-cat "$ENV_DIR/HEROKU_SPRETTUR_URL"
-
 if [ -f $ENV_DIR/HEROKU_SPRETTUR_URL ]; then
   SPRETTUR_URL=$(cat $ENV_DIR/HEROKU_SPRETTUR_URL)
   echo "-----> Installing sprettur from $SPRETTUR_URL"
@@ -31,6 +27,7 @@ SPRETTUR_DIR=$BUILD_DIR/.sprettur/bin
 mkdir -p $SPRETTUR_DIR
 curl -s -o $SPRETTUR_DIR/sprettur $SPRETTUR_URL
 chmod +x $SPRETTUR_DIR/sprettur
+echo "       sprettur installed"
 
 echo "-----> Removing Procfile"
 PROCFILE="$BUILD_DIR/Procfile"
@@ -42,10 +39,10 @@ else
   echo "       no Procfile found"
 fi
 
+echo "-----> Exporting sprettur configuration"
 mkdir -p $BUILD_DIR/.profile.d
 echo "export STACK=$STACK" >> $BUILD_DIR/.profile.d/sprettur.sh
 echo 'export PATH=$PATH:$HOME/.sprettur/bin/' >> $BUILD_DIR/.profile.d/sprettur.sh
-
-echo "-----> sprettur done"
+echo "       sprettur configuration exported"
 
 exit 0


### PR DESCRIPTION
This does 3 things:

1. Uses the correct argument to determine `HEROKU_SPRETTUR_URL`
2. Logs out anytime we install with a non-standard sprettur
3. Slightly more verbose logging where all steps are logged with start and finish.