### PR TITLE
symlink sprettur > ci to correct location

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -41,11 +41,13 @@ fi
 
 echo "-----> Exporting sprettur configuration"
 mkdir -p $BUILD_DIR/.profile.d
-echo "export STACK=$STACK" >> $BUILD_DIR/.profile.d/sprettur.sh
-echo 'export PATH=$PATH:$HOME/.sprettur/bin/' >> $BUILD_DIR/.profile.d/sprettur.sh
 
-ln -s $SPRETTUR_DIR/sprettur $SPRETTUR_DIR/ci
-chmod +x $SPRETTUR_DIR/ci
+SPRETTUR_BIN_DIR=$HOME/.sprettur/bin/
+echo "export STACK=$STACK" >> $BUILD_DIR/.profile.d/sprettur.sh
+echo 'export PATH=$PATH:$SPRETTUR_BIN_DIR' >> $BUILD_DIR/.profile.d/sprettur.sh
+
+ln -s $SPRETTUR_BIN_DIR/sprettur $SPRETTUR_BIN_DIR/ci
+chmod +x $SPRETTUR_BIN_DIR/ci
 
 echo "       sprettur configuration exported"
 


### PR DESCRIPTION
I've tested this out in a `ci:debug` session and it works this time.