### PR TITLE
Set TERM=dumb in .profile.d script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ mkdir -p $BUILD_DIR/.profile.d
 
 PROFILE_D=$BUILD_DIR/.profile.d/sprettur.sh
 echo "export STACK=$STACK" >> $PROFILE_D
-echo "export PATH=$PATH:$HOME/.sprettur/bin/" >> $PROFILE_D
+echo "export PATH=\$PATH:\$HOME/.sprettur/bin/" >> $PROFILE_D
 echo "export TERM=\${TERM:-xterm}" >> $PROFILE_D
 
 # Symlink ci -> sprettur

--- a/bin/compile
+++ b/bin/compile
@@ -42,8 +42,10 @@ fi
 echo "-----> Exporting sprettur configuration"
 mkdir -p $BUILD_DIR/.profile.d
 
-echo "export STACK=$STACK" >> $BUILD_DIR/.profile.d/sprettur.sh
-echo 'export PATH=$PATH:$HOME/.sprettur/bin/' >> $BUILD_DIR/.profile.d/sprettur.sh
+PROFILE_D=$BUILD_DIR/.profile.d/sprettur.sh
+echo "export STACK=$STACK" >> $PROFILE_D
+echo "export PATH=$PATH:$HOME/.sprettur/bin/" >> $PROFILE_D
+echo "export TERM=\${TERM:-xterm}" >> $PROFILE_D
 
 # Symlink ci -> sprettur
 cd $SPRETTUR_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -45,7 +45,7 @@ mkdir -p $BUILD_DIR/.profile.d
 PROFILE_D=$BUILD_DIR/.profile.d/sprettur.sh
 echo "export STACK=$STACK" >> $PROFILE_D
 echo "export PATH=\$PATH:\$HOME/.sprettur/bin/" >> $PROFILE_D
-echo "export TERM=\${TERM:-xterm}" >> $PROFILE_D
+echo "export TERM=\${TERM:-dumb}" >> $PROFILE_D
 
 # Symlink ci -> sprettur
 cd $SPRETTUR_DIR


### PR DESCRIPTION
This will avoid issues like `No value for $TERM and no -T specified` in test scripts.