### PR TITLE
[3PP Automation] Update Security Alerts GHA

### DIFF
--- a/.github/workflows/push_dependabot_metadata.yml
+++ b/.github/workflows/push_dependabot_metadata.yml
@@ -9,10 +9,26 @@ jobs:
   send-alerts:
     runs-on: pub-hk-ubuntu-24.04-ip
     steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.SECURITY_ALERTS_GH_APP_ID }}
+          private-key: ${{ secrets.SECURITY_ALERTS_GH_APP_PRIVKEY }}
+          owner: heroku
+
+      - name: Checkout code with security-alerts-action
+        uses: actions/checkout@v4
+        with:
+          repository: heroku/security-alerts-action
+          token: ${{ steps.app-token.outputs.token }}
+          ref: for-public-repos-only
+
       - name: Send data to Security Alerts
-        uses: heroku/security-alerts-action@main
+        uses: ./
         with:
           gh-app-id: ${{ secrets.SECURITY_ALERTS_GH_APP_ID }}
           gh-app-privkey: ${{ secrets.SECURITY_ALERTS_GH_APP_PRIVKEY }}
           webhook-url: ${{ secrets.SECURITY_ALERTS_WEBHOOK_URL }}
           sa-token: ${{ secrets.SECURITY_ALERTS_TOKEN }}
+          gh-app-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
# Context
Update gha to use for-public-repos-only branch of security-alerts-action. 

# Testing
https://github.com/heroku/security-alerts-pub-test/actions/runs/11233186860/job/31226372591

# Reference
[GUS-W-16396709](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001y2HV1YAM/view)